### PR TITLE
Adjusted deactivate()

### DIFF
--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -6,7 +6,7 @@ export default {
    subscriptions: null,
 
    deactivate() {
-      this.html.destroy();
+      this.subscriptions.dispose();
    },
 
    activate(state) {


### PR DESCRIPTION
The deactivate function threw error as the destroy function did not exist. I tried to figure out what it was supposed to be called on, but to no avail. But everything seems to deactivate fine without it.

Also threw in the standard subscriptions.dispose() to remove the shortcuts on deactivate.

I noticed this all because I had developer tools open and reloading atom window with "Preserve log" enabled.