### PR TITLE
Change the default location to the Right Dock. Use config setting to set a preference.

### DIFF
--- a/lib/atom-browser-view.js
+++ b/lib/atom-browser-view.js
@@ -43,7 +43,7 @@ export default class AtomGoogleView {
          element: this.view,
          getTitle: () => 'Atom Browser',
          getURI: () => 'atom://atom-web/webview',
-         getDefaultLocation: () => 'bottom'
+         getDefaultLocation: () => 'right'
       }
 
       //Select this html for later

--- a/lib/atom-browser-view.js
+++ b/lib/atom-browser-view.js
@@ -16,8 +16,6 @@ const viewSettings = [
    }
 ]
 
-
-
 export default class AtomGoogleView {
 
    /*------------------------------------------------------------------------*/
@@ -44,11 +42,13 @@ export default class AtomGoogleView {
       this.view.appendChild(this.elements.navbar)
 
       //view.innerHTML += tabs
+      var dockLocation = atom.config.get('atom-browser.viewDefaultLocation')
+      dockLocation = dockLocation ? dockLocation : 'right'
       this.workspace = {
          element: this.view,
          getTitle: () => 'Atom Browser',
          getURI: () => 'atom://atom-web/webview',
-         getDefaultLocation: () => 'right'
+         getDefaultLocation: () => dockLocation
       }
 
       //Select this html for later

--- a/lib/atom-browser-view.js
+++ b/lib/atom-browser-view.js
@@ -8,6 +8,11 @@ const viewSettings = [
       name: 'atom-browser.viewShowBackground',
       element: 'webview',
       class: 'showBackground'
+   },
+   {
+      name: 'atom-browser.viewDefaultLocation',
+      element: 'webview',
+      class: 'defaultLocation'
    }
 ]
 
@@ -67,11 +72,14 @@ export default class AtomGoogleView {
    loadAndWatchViewSettings(){
       // Loop the settings and toggle on or off
       for(var setting of viewSettings){
-            if(!setting.listening) this.watchSetting(setting)
+         if(!setting.listening) this.watchSetting(setting)
 
-            var value = atom.config.get(setting.name)
-            var element = this.elements[setting.element]
-            element.classList.toggle(setting.class, value)
+            if(setting.name === 'showBackground')
+              var value = atom.config.get(setting.name)
+              var element = this.elements[setting.element]
+              element.classList.toggle(setting.class, value)
+
+
       }
    }
 

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -29,10 +29,10 @@ export default {
       }))
    },
    showHide(){
-      if(atom.workspace.getBottomDock().state.visible){
-         atom.workspace.getBottomDock().hide()
+      if(atom.workspace.getRightDock().state.visible){
+         atom.workspace.getRightDock().hide()
       } else {
-         atom.workspace.getBottomDock().show()
+         atom.workspace.getRightDock().show()
          atom.workspace.open(this.view.workspace)
       }
    },

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -37,9 +37,6 @@ export default {
          case 'right':
             dock = atom.workspace.getRightDock()
             break
-         case 'left':
-            dock = atom.workspace.getLeftDock()
-            break
          case 'bottom':
             dock = atom.workspace.getBottomDock()
       }

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -29,10 +29,25 @@ export default {
       }))
    },
    showHide(){
-      if(atom.workspace.getRightDock().state.visible){
-         atom.workspace.getRightDock().hide()
+      var dockLocation = atom.config.get('atom-browser.viewDefaultLocation')
+      dockLocation = dockLocation ? dockLocation : 'right'
+
+      var dock
+      switch (dockLocation) {
+         case 'right':
+            dock = atom.workspace.getRightDock()
+            break
+         case 'left':
+            dock = atom.workspace.getLeftDock()
+            break
+         case 'bottom':
+            dock = atom.workspace.getBottomDock()
+      }
+
+      if(dock.state.visible){
+         dock.hide()
       } else {
-         atom.workspace.getRightDock().show()
+         dock.show()
          atom.workspace.open(this.view.workspace)
       }
    },

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -11,7 +11,7 @@ export default {
 
    activate(state) {
       this.view = new AtomBrowserView(state.AtomBrowserViewState)
-		this.reloading = false
+      this.reloading = false
       this.setUpTheKeyBinds()
       this.listen()
    },

--- a/package.json
+++ b/package.json
@@ -50,17 +50,13 @@
     },
     "viewDefaultLocation": {
       "title": "Default Location",
-      "description": "Choose the default dock location for the Atom Browser: right, left or bottom. (Reload Atom to change the dock location.)",
+      "description": "Choose the default dock location for the Atom Browser: right or bottom. (Reload Atom to change the dock location.)",
       "type": "string",
       "default": "right",
       "enum": [
         {
           "value": "right",
           "description": "Right Dock"
-        },
-        {
-          "value": "left",
-          "description": "Left Dock"
         },
         {
           "value": "bottom",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,26 @@
       "description": "The default background is dark grey. Enable this for white",
       "type": "boolean",
       "default": false
+    },
+    "viewDefaultLocation": {
+      "title": "Default Location",
+      "description": "Choose the default dock location for the Atom Browser: right, left or bottom",
+      "type": "string",
+      "default": "right",
+      "enum": [
+        {
+          "value": "right",
+          "description": "Right Dock"
+        },
+        {
+          "value": "left",
+          "description": "Left Dock"
+        },
+        {
+          "value": "bottom",
+          "description": "Bottom Dock"
+        }
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "viewDefaultLocation": {
       "title": "Default Location",
-      "description": "Choose the default dock location for the Atom Browser: right, left or bottom",
+      "description": "Choose the default dock location for the Atom Browser: right, left or bottom. (Reload Atom to change the dock location.)",
       "type": "string",
       "default": "right",
       "enum": [


### PR DESCRIPTION
The aesthetics and behaviour of the Atom Browser are much better than the alternatives that I found. The only thing that I had an issue with was a preference I have for having code on the left and the browser preview on the right. So, I changed the default to the Right Dock and added a configuration setting to switch the default location between the Right and Bottom Docks.

I had also included Left as an option, but it conflicted with the location of the Project tree view, so I removed it.