### PR TITLE
2020.1: repair dock reset

### DIFF
--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -227,5 +227,6 @@ export default class AtomBrowserViewBrowser {
    destroy() {
       this.element.remove()
       this.subscriptions.dispose()
+      this.listener && this.listener.destroy()
    }
 }

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -15,11 +15,11 @@ import {
 export default {
    activate() {
       this.subscriptions = null
-      this.dockLocation = 'bottom'
-      this.initialUrl = ''
+      this.dockLocation = atom.config.get(CONFIG_DEFAULT_LOCATION)
+      this.showBackground = atom.config.get(CONFIG_WEBVIEW_BACKGROUND)
+      this.initialUrl = atom.config.get(CONFIG_INITIAL_URL)
       this.showIcon = false
       this.view = undefined
-      this.showBackground = false
 
       this.addSubscriptions()
    },
@@ -96,10 +96,6 @@ export default {
    },
 
    initializeView() {
-      this.dockLocation = atom.config.get(CONFIG_DEFAULT_LOCATION) || this.dockLocation
-      this.showBackground = atom.config.get(CONFIG_WEBVIEW_BACKGROUND)
-      this.initialUrl = atom.config.get(CONFIG_INITIAL_URL)
-
       this.view = new AtomBrowserViewBrowser({
          defaultLocation: this.dockLocation,
          showBackground: this.showBackground,
@@ -214,7 +210,9 @@ export default {
    },
 
    onDidMoveItem({ item }, location) {
-      this.dockLocation = location
-      atom.config.set(CONFIG_DEFAULT_LOCATION, location)
+      if (item instanceof AtomBrowserViewBrowser) {
+         this.dockLocation = location
+         atom.config.set(CONFIG_DEFAULT_LOCATION, location)
+      }
    },
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
          "title": "Default Location",
          "description": "Choose the default dock location for the Atom Browser: right or bottom",
          "type": "string",
-         "default": "right",
+         "default": "bottom",
          "enum": [
             {
                "value": "right",


### PR DESCRIPTION
Fixing bug atom browsers dock location was being reset. This was due to listening on all dock move events! Now we only change dock location when the change is correct item type.