### PR TITLE
2020.3: add url overwrite feature

### DIFF
--- a/lib/atom-browser-confignames.js
+++ b/lib/atom-browser-confignames.js
@@ -6,6 +6,7 @@ const CONFIG_RELOAD_DELAY = 'atom-browser.reloadDelay'
 const CONFIG_AUTO_PREFIX = 'atom-browser.autoPrefix'
 const CONFIG_EMITTER_ENABLED = 'atom-browser.z_experimental.emitterEnabled'
 const CONFIG_AUTO_DEVTOOLS = 'atom-browser.z_experimental.devtools'
+const CONFIG_URL_OVERWRITE = 'atom-browser.z_experimental.url_overwrite'
 
 module.exports = {
    CONFIG_WEBVIEW_BACKGROUND,
@@ -15,5 +16,6 @@ module.exports = {
    CONFIG_RELOAD_DELAY,
    CONFIG_AUTO_PREFIX,
    CONFIG_AUTO_DEVTOOLS,
-   CONFIG_EMITTER_ENABLED
+   CONFIG_EMITTER_ENABLED,
+   CONFIG_URL_OVERWRITE,
 }

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -10,6 +10,7 @@ import {
    CONFIG_AUTO_PREFIX,
    CONFIG_EMITTER_ENABLED,
    CONFIG_AUTO_DEVTOOLS,
+   CONFIG_URL_OVERWRITE,
 } from './atom-browser-confignames'
 
 export default class AtomBrowserViewBrowser {
@@ -161,6 +162,27 @@ export default class AtomBrowserViewBrowser {
    /*------------------------------------------------------------------------*/
    setURL(url) {
       if (url.length === 0) return
+
+      // URL Overrides defined in config
+      try {
+         const urlOverwrites = JSON.parse(atom.config.get(CONFIG_URL_OVERWRITE))
+         for (const overwrite of urlOverwrites) {
+            url = url.replace(overwrite.replace, overwrite.with);
+         }
+
+      } catch(e) {
+         console.error('ATOM-BROWSER: url overwrite error', e)
+         atom.notifications.addError('The package `atom-browser` could not parse the setting URL Overwrites. Check to make sure this is valid JSON', {
+            dismissable: true,
+            buttons: [
+               {
+                  text: 'Go to settings',
+                  onDidClick: () => atom.workspace.open("atom://config/packages/atom-browser")
+               }
+            ]
+         })
+      }
+
 
       // search google
       if (!url.includes('://') && !url.startsWith('localhost'))

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -89,6 +89,10 @@ export default class AtomBrowserViewBrowser {
       })
 
       this.html.webview.addEventListener('did-fail-load', (error) => {
+         const ERROR_CODE_ABORTED = -3
+
+         if (error.errorCode === ERROR_CODE_ABORTED) return
+
          this.html.webviewErrorMessage.innerHTML = error.errorDescription
          this.html.webviewErrorMessage.style.textAlign = 'center'
          this.html.webviewErrorIcon.setAttribute('class', 'icon icon-alert')

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -70,7 +70,7 @@ export default {
       if (!selected) return
 
       var path = selected.getAttribute('data-path')
-      const fileURL = 'file:///' + path
+      const fileURL = 'file://' + path
 
       this.view.setURL(fileURL)
    },

--- a/package.json
+++ b/package.json
@@ -121,6 +121,12 @@
                "title": "Automatically open devtools",
                "type": "boolean",
                "default": "false"
+            },
+            "url_overwrite": {
+               "title": "URL Overwrites",
+               "description": "Paths to overwrite when right click previewing a file. Allows you to map a filepath to your localhost!",
+               "type": "string",
+               "default": "[ { \"replace\": \"example/filepath\", \"with\": \"localhost:8000\" } ]"
             }
          }
       }


### PR DESCRIPTION
Hi this adds a new feature for mapping/overwritting paths. Under experimental features there is a text input for url overwrites. 

```json
[ 
  { "replace": "example/filepath", "with": "localhost:8000" } 
]
```

![May-19-2020 23-39-25](https://user-images.githubusercontent.com/21677355/82405617-09169400-9a2a-11ea-9f28-c35b794948b2.gif)
