### PR TITLE
2020.5: updates

### DIFF
--- a/lib/atom-browser-confignames.js
+++ b/lib/atom-browser-confignames.js
@@ -10,6 +10,7 @@ const CONFIG_EMITTER_ENABLED = 'atom-browser.z_experimental.emitterEnabled'
 const CONFIG_AUTO_DEVTOOLS = 'atom-browser.z_experimental.devtools'
 const CONFIG_URL_OVERWRITE = 'atom-browser.z_experimental.url_overwrite'
 const CONFIG_STATIC_SERVE = 'atom-browser.z_experimental.static_server'
+const CONFIG_ZOOM_FACTOR = 'atom-browser.showZoomFactor'
 
 module.exports = {
    CONFIG_AUTO_PREFIX,
@@ -24,4 +25,5 @@ module.exports = {
    CONFIG_STATIC_SERVE,
    CONFIG_URL_OVERWRITE,
    CONFIG_WEBVIEW_BACKGROUND,
+   CONFIG_ZOOM_FACTOR,
 }

--- a/lib/atom-browser-confignames.js
+++ b/lib/atom-browser-confignames.js
@@ -7,15 +7,17 @@ const CONFIG_AUTO_PREFIX = 'atom-browser.autoPrefix'
 const CONFIG_EMITTER_ENABLED = 'atom-browser.z_experimental.emitterEnabled'
 const CONFIG_AUTO_DEVTOOLS = 'atom-browser.z_experimental.devtools'
 const CONFIG_URL_OVERWRITE = 'atom-browser.z_experimental.url_overwrite'
+const CONFIG_STATIC_SERVE = 'atom-browser.z_experimental.static_server'
 
 module.exports = {
-   CONFIG_WEBVIEW_BACKGROUND,
-   CONFIG_DEFAULT_LOCATION,
-   CONFIG_INITIAL_URL,
-   CONFIG_SHOW_ICON,
-   CONFIG_RELOAD_DELAY,
    CONFIG_AUTO_PREFIX,
    CONFIG_AUTO_DEVTOOLS,
+   CONFIG_DEFAULT_LOCATION,
    CONFIG_EMITTER_ENABLED,
+   CONFIG_INITIAL_URL,
+   CONFIG_RELOAD_DELAY,
+   CONFIG_SHOW_ICON,
+   CONFIG_STATIC_SERVE,
    CONFIG_URL_OVERWRITE,
+   CONFIG_WEBVIEW_BACKGROUND,
 }

--- a/lib/atom-browser-confignames.js
+++ b/lib/atom-browser-confignames.js
@@ -5,6 +5,7 @@ const CONFIG_SHOW_ICON = 'atom-browser.showIcon'
 const CONFIG_RELOAD_BY_DEFAULT = 'atom-browser.reloadByDefault'
 const CONFIG_RELOAD_DELAY = 'atom-browser.reloadDelay'
 const CONFIG_AUTO_PREFIX = 'atom-browser.autoPrefix'
+const CONFIG_SHOW_ZOOM = 'atom-browser.showZoomButtons'
 const CONFIG_EMITTER_ENABLED = 'atom-browser.z_experimental.emitterEnabled'
 const CONFIG_AUTO_DEVTOOLS = 'atom-browser.z_experimental.devtools'
 const CONFIG_URL_OVERWRITE = 'atom-browser.z_experimental.url_overwrite'
@@ -19,6 +20,7 @@ module.exports = {
    CONFIG_RELOAD_BY_DEFAULT,
    CONFIG_RELOAD_DELAY,
    CONFIG_SHOW_ICON,
+   CONFIG_SHOW_ZOOM,
    CONFIG_STATIC_SERVE,
    CONFIG_URL_OVERWRITE,
    CONFIG_WEBVIEW_BACKGROUND,

--- a/lib/atom-browser-confignames.js
+++ b/lib/atom-browser-confignames.js
@@ -2,6 +2,7 @@ const CONFIG_WEBVIEW_BACKGROUND = 'atom-browser.showBackground'
 const CONFIG_DEFAULT_LOCATION = 'atom-browser.defaultLocation'
 const CONFIG_INITIAL_URL = 'atom-browser.initialUrl'
 const CONFIG_SHOW_ICON = 'atom-browser.showIcon'
+const CONFIG_RELOAD_BY_DEFAULT = 'atom-browser.reloadByDefault'
 const CONFIG_RELOAD_DELAY = 'atom-browser.reloadDelay'
 const CONFIG_AUTO_PREFIX = 'atom-browser.autoPrefix'
 const CONFIG_EMITTER_ENABLED = 'atom-browser.z_experimental.emitterEnabled'
@@ -15,6 +16,7 @@ module.exports = {
    CONFIG_DEFAULT_LOCATION,
    CONFIG_EMITTER_ENABLED,
    CONFIG_INITIAL_URL,
+   CONFIG_RELOAD_BY_DEFAULT,
    CONFIG_RELOAD_DELAY,
    CONFIG_SHOW_ICON,
    CONFIG_STATIC_SERVE,

--- a/lib/atom-browser-server.js
+++ b/lib/atom-browser-server.js
@@ -1,0 +1,25 @@
+const express = require('express')
+
+class AtomBrowserServer {
+   start(path, then) {
+      if (this.server) this.tearDown()
+      this.app = express()
+
+      this.app.use(express.static(path))
+      
+      this.server = this.app.listen(7654, () => {
+         console.log('AtomBrowserServer started on: ', 7654)
+         then('http://localhost:7654')
+      })
+   }
+   
+   tearDown() {
+      if (!this.server) return
+      
+      console.log('AtomBrowserServer closed')
+      this.server.close()
+      this.server = undefined
+   }
+}
+
+module.exports = AtomBrowserServer

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -6,10 +6,10 @@ const ViewNavbar = require('./views/Navbar')
 const ViewWebview = require('./views/Webview')
 
 import {
-   CONFIG_RELOAD_DELAY,
+   CONFIG_AUTO_DEVTOOLS,
    CONFIG_AUTO_PREFIX,
    CONFIG_EMITTER_ENABLED,
-   CONFIG_AUTO_DEVTOOLS,
+   CONFIG_RELOAD_DELAY,
    CONFIG_URL_OVERWRITE,
 } from './atom-browser-confignames'
 
@@ -18,6 +18,7 @@ export default class AtomBrowserViewBrowser {
       defaultLocation,
       showBackground,
       initialUrl,
+      reloadByDefault,
    }) {
       this.subscriptions = new CompositeDisposable()
       this.showBackground = showBackground
@@ -30,7 +31,7 @@ export default class AtomBrowserViewBrowser {
 
       this.element = document.createElement('div')
       this.element.setAttribute('id', 'atombrowser-view')
-      this.element.innerHTML += ViewNavbar()
+      this.element.innerHTML += ViewNavbar({ reloadByDefault })
       this.element.innerHTML += ViewWebview({ showBackground })
 
       this.getTitle = () => 'Atom Browser'

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -11,6 +11,7 @@ import {
    CONFIG_EMITTER_ENABLED,
    CONFIG_RELOAD_DELAY,
    CONFIG_URL_OVERWRITE,
+   CONFIG_ZOOM_FACTOR,
 } from './atom-browser-confignames'
 
 export default class AtomBrowserViewBrowser {
@@ -20,6 +21,7 @@ export default class AtomBrowserViewBrowser {
       showZoomButtons,
       initialUrl,
       reloadByDefault,
+      zoomFactor
    }) {
       this.subscriptions = new CompositeDisposable()
       this.showBackground = showBackground
@@ -29,10 +31,11 @@ export default class AtomBrowserViewBrowser {
       this.iframeInfo = {}
       this.uri = 'atom://atom-web/webview' + Math.random()
       this.openedDevTools = false
+      this.zoomFactor = zoomFactor
 
       this.element = document.createElement('div')
       this.element.setAttribute('id', 'atombrowser-view')
-      this.element.innerHTML += ViewNavbar({ reloadByDefault, showZoomButtons })
+      this.element.innerHTML += ViewNavbar({ reloadByDefault, showZoomButtons, zoomFactor })
       this.element.innerHTML += ViewWebview({ showBackground })
 
       this.getTitle = () => 'Atom Browser'
@@ -54,6 +57,9 @@ export default class AtomBrowserViewBrowser {
          webviewErrorIcon: this.element.querySelector('#atombrowser-webview-failed-load i'),
          addressbar: this.element.querySelector('#atombrowser-addressbar'),
          zoomBar: this.element.querySelector('.zoom-bar'),
+         btnZoomOut: this.element.querySelector('#atombrowser-btn-zoom-out'),
+         inputZoom: this.element.querySelector('#atombrowser-input-zoom'),
+         btnZoomIn: this.element.querySelector('#atombrowser-btn-zoom-in'),
          btn: {
             reload: this.element.querySelector('#atombrowser-btn-reload'),
             back: this.element.querySelector('#atombrowser-btn-back'),
@@ -87,6 +93,7 @@ export default class AtomBrowserViewBrowser {
       this.html.webview.addEventListener('did-stop-loading', () => {
          this.html.btn.reload.classList.remove('loading')
          this.html.addressbar.value = this.html.webview.getURL()
+         this.zoomUpdate()
 
          this.ipcConnect()
       })
@@ -106,7 +113,7 @@ export default class AtomBrowserViewBrowser {
          // console.log('[ATOM BROWSER] received data', event.channel)
          this.iframeInfo = JSON.parse(event.channel)
       })
-
+      
       // url bar
       var lastCall = Date.now()
       this.html.addressbar.addEventListener('paste', (e) => {
@@ -126,6 +133,10 @@ export default class AtomBrowserViewBrowser {
          var active = !this.html.btn.livereload.classList.contains('active')
          this.html.btn.livereload.classList.toggle('active', active)
       })
+      
+      // zoombar
+      this.html.btnZoomOut.addEventListener('click', () => this.zoomOut())
+      this.html.btnZoomIn.addEventListener('click', () => this.zoomIn())
    }
 
    isInDom() {
@@ -246,14 +257,38 @@ export default class AtomBrowserViewBrowser {
          this.html.webview.goBack()
    }
 
+   // zoom
+   zoomOut() {
+      this.zoomFactor -= 0.1
+      this.zoomUpdate()
+   }
+   
+   zoomIn() {
+      this.zoomFactor += 0.1
+      this.zoomUpdate()
+   }
+   
+   zoomSet(zoomFactor) {
+      this.zoomFactor = zoomFactor
+      this.zoomUpdate()
+   }
+   
+   zoomUpdate() {
+      this.zoomFactor = Math.round(this.zoomFactor * 100)/100
+      atom.config.set(CONFIG_ZOOM_FACTOR, this.zoomFactor)
+      this.html.inputZoom.value = Math.round(this.zoomFactor * 100)
+      if (this.html.webview.getWebContents()) {
+         this.html.webview.setZoomFactor(this.zoomFactor)
+      }
+   }
+   
+   zoomToggle(showZoomButtons) {
+      this.html.zoomBar.classList.toggle('hidden', !showZoomButtons)
+   }
+   
    applySettingViewBackground(show) {
       this.showBackground = show
       this.html.webview.classList.toggle('show-background', this.showBackground)
-   }
-   
-   toggleZoomButtons(showZoomButtons) {
-      console.log('hello', showZoomButtons);
-      this.html.zoomBar.classList.toggle('hidden', !showZoomButtons)
    }
 
    destroy() {

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -205,7 +205,7 @@ export default class AtomBrowserViewBrowser {
    reload() {
       if (this.isInDom() && this.html.webview.getWebContents()) {
          this.ipcDisconnect()
-         this.html.webview.reload()
+         this.html.webview.reloadIgnoringCache()
       }
    }
 

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -94,7 +94,6 @@ export default class AtomBrowserViewBrowser {
          this.html.btn.reload.classList.remove('loading')
          this.html.addressbar.value = this.html.webview.getURL()
          this.zoomUpdate()
-
          this.ipcConnect()
       })
 
@@ -113,7 +112,11 @@ export default class AtomBrowserViewBrowser {
          // console.log('[ATOM BROWSER] received data', event.channel)
          this.iframeInfo = JSON.parse(event.channel)
       })
-      
+
+      this.html.webview.addEventListener('new-window', async (e) => {
+         this.setURL(e.url);
+      })
+
       // url bar
       var lastCall = Date.now()
       this.html.addressbar.addEventListener('paste', (e) => {
@@ -133,7 +136,7 @@ export default class AtomBrowserViewBrowser {
          var active = !this.html.btn.livereload.classList.contains('active')
          this.html.btn.livereload.classList.toggle('active', active)
       })
-      
+
       // zoombar
       this.html.btnZoomOut.addEventListener('click', () => this.zoomOut())
       this.html.btnZoomIn.addEventListener('click', () => this.zoomIn())
@@ -262,17 +265,17 @@ export default class AtomBrowserViewBrowser {
       this.zoomFactor -= 0.1
       this.zoomUpdate()
    }
-   
+
    zoomIn() {
       this.zoomFactor += 0.1
       this.zoomUpdate()
    }
-   
+
    zoomSet(zoomFactor) {
       this.zoomFactor = zoomFactor
       this.zoomUpdate()
    }
-   
+
    zoomUpdate() {
       this.zoomFactor = Math.round(this.zoomFactor * 100)/100
       atom.config.set(CONFIG_ZOOM_FACTOR, this.zoomFactor)
@@ -281,11 +284,11 @@ export default class AtomBrowserViewBrowser {
          this.html.webview.setZoomFactor(this.zoomFactor)
       }
    }
-   
+
    zoomToggle(showZoomButtons) {
       this.html.zoomBar.classList.toggle('hidden', !showZoomButtons)
    }
-   
+
    applySettingViewBackground(show) {
       this.showBackground = show
       this.html.webview.classList.toggle('show-background', this.showBackground)

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -17,6 +17,7 @@ export default class AtomBrowserViewBrowser {
    constructor({
       defaultLocation,
       showBackground,
+      showZoomButtons,
       initialUrl,
       reloadByDefault,
    }) {
@@ -31,7 +32,7 @@ export default class AtomBrowserViewBrowser {
 
       this.element = document.createElement('div')
       this.element.setAttribute('id', 'atombrowser-view')
-      this.element.innerHTML += ViewNavbar({ reloadByDefault })
+      this.element.innerHTML += ViewNavbar({ reloadByDefault, showZoomButtons })
       this.element.innerHTML += ViewWebview({ showBackground })
 
       this.getTitle = () => 'Atom Browser'
@@ -52,6 +53,7 @@ export default class AtomBrowserViewBrowser {
          webviewErrorMessage: this.element.querySelector('#atombrowser-webview-failed-load .message'),
          webviewErrorIcon: this.element.querySelector('#atombrowser-webview-failed-load i'),
          addressbar: this.element.querySelector('#atombrowser-addressbar'),
+         zoomBar: this.element.querySelector('.zoom-bar'),
          btn: {
             reload: this.element.querySelector('#atombrowser-btn-reload'),
             back: this.element.querySelector('#atombrowser-btn-back'),
@@ -247,6 +249,11 @@ export default class AtomBrowserViewBrowser {
    applySettingViewBackground(show) {
       this.showBackground = show
       this.html.webview.classList.toggle('show-background', this.showBackground)
+   }
+   
+   toggleZoomButtons(showZoomButtons) {
+      console.log('hello', showZoomButtons);
+      this.html.zoomBar.classList.toggle('hidden', !showZoomButtons)
    }
 
    destroy() {

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -10,15 +10,18 @@ import {
    CONFIG_INITIAL_URL,
    CONFIG_RELOAD_BY_DEFAULT,
    CONFIG_SHOW_ICON,
+   CONFIG_SHOW_ZOOM,
    CONFIG_STATIC_SERVE,
    CONFIG_WEBVIEW_BACKGROUND,
 } from './atom-browser-confignames'
 
 export default {
    activate() {
+      console.log('dev mode')
       this.subscriptions = null
       this.dockLocation = atom.config.get(CONFIG_DEFAULT_LOCATION)
       this.showBackground = atom.config.get(CONFIG_WEBVIEW_BACKGROUND)
+      this.showZoomButtons = atom.config.get(CONFIG_SHOW_ZOOM)
       this.initialUrl = atom.config.get(CONFIG_INITIAL_URL)
       this.reloadByDefault = atom.config.get(CONFIG_RELOAD_BY_DEFAULT)
       this.showIcon = false
@@ -61,6 +64,7 @@ export default {
          atom.config.onDidChange(CONFIG_WEBVIEW_BACKGROUND, () => this.changeConfigWebviewBackground()),
          atom.config.onDidChange(CONFIG_SHOW_ICON, () => this.changeConfigShowIcon()),
          atom.config.onDidChange(CONFIG_EMITTER_ENABLED, () => this.changeConfigEmitter()),
+         atom.config.onDidChange(CONFIG_SHOW_ZOOM, () => this.changeShowZoom()),
          atom.config.onDidChange(CONFIG_RELOAD_BY_DEFAULT, () => this.changeReloadByDefault()),
          atom.workspace.getRightDock().getPanes()[0].onWillDestroyItem((e) => this.onDestroyItem(e)),
          atom.workspace.getBottomDock().getPanes()[0].onWillDestroyItem((e) => this.onDestroyItem(e)),
@@ -137,6 +141,7 @@ export default {
          showBackground: this.showBackground,
          reloadByDefault: this.reloadByDefault,
          initialUrl: this.initialUrl,
+         showZoomButtons: this.showZoomButtons,
       })
 
       atom.workspace.open(this.view)  
@@ -184,11 +189,17 @@ export default {
    },
 
    changeConfigEmitter() {
-      this.view.ipcToggle()
+      this.view && this.view.ipcToggle()
    },
    
    changeReloadByDefault() {
       this.reloadByDefault = atom.config.get(CONFIG_RELOAD_BY_DEFAULT)
+   },
+   
+   changeShowZoom() {
+      this.showZoomButtons = atom.config.get(CONFIG_SHOW_ZOOM)
+      console.log('uhhhh', this.showZoomButtons, atom.config.get(CONFIG_SHOW_ZOOM), CONFIG_SHOW_ZOOM)
+      this.view && this.view.toggleZoomButtons(this.showZoomButtons)
    },
 
    /*------------------------------------------------------------------------*/

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -5,13 +5,13 @@ import AtomBrowserViewIcon from './atom-browser-view-icon'
 import AtomBrowserServer from './atom-browser-server'
 
 import {
-   CONFIG_WEBVIEW_BACKGROUND,
    CONFIG_DEFAULT_LOCATION,
-   CONFIG_INITIAL_URL,
-   CONFIG_SHOW_ICON,
    CONFIG_EMITTER_ENABLED,
-   CONFIG_AUTO_DEVTOOLS,
+   CONFIG_INITIAL_URL,
+   CONFIG_RELOAD_BY_DEFAULT,
+   CONFIG_SHOW_ICON,
    CONFIG_STATIC_SERVE,
+   CONFIG_WEBVIEW_BACKGROUND,
 } from './atom-browser-confignames'
 
 export default {
@@ -20,6 +20,7 @@ export default {
       this.dockLocation = atom.config.get(CONFIG_DEFAULT_LOCATION)
       this.showBackground = atom.config.get(CONFIG_WEBVIEW_BACKGROUND)
       this.initialUrl = atom.config.get(CONFIG_INITIAL_URL)
+      this.reloadByDefault = atom.config.get(CONFIG_RELOAD_BY_DEFAULT)
       this.showIcon = false
       this.view = undefined
       this.server = new AtomBrowserServer
@@ -60,6 +61,7 @@ export default {
          atom.config.onDidChange(CONFIG_WEBVIEW_BACKGROUND, () => this.changeConfigWebviewBackground()),
          atom.config.onDidChange(CONFIG_SHOW_ICON, () => this.changeConfigShowIcon()),
          atom.config.onDidChange(CONFIG_EMITTER_ENABLED, () => this.changeConfigEmitter()),
+         atom.config.onDidChange(CONFIG_RELOAD_BY_DEFAULT, () => this.changeReloadByDefault()),
          atom.workspace.getRightDock().getPanes()[0].onWillDestroyItem((e) => this.onDestroyItem(e)),
          atom.workspace.getBottomDock().getPanes()[0].onWillDestroyItem((e) => this.onDestroyItem(e)),
          atom.workspace.getRightDock().getPanes()[0].onDidAddItem((e) => this.onDidMoveItem(e, 'right')),
@@ -133,6 +135,7 @@ export default {
       this.view = new AtomBrowserViewBrowser({
          defaultLocation: this.dockLocation,
          showBackground: this.showBackground,
+         reloadByDefault: this.reloadByDefault,
          initialUrl: this.initialUrl,
       })
 
@@ -182,6 +185,10 @@ export default {
 
    changeConfigEmitter() {
       this.view.ipcToggle()
+   },
+   
+   changeReloadByDefault() {
+      this.reloadByDefault = atom.config.get(CONFIG_RELOAD_BY_DEFAULT)
    },
 
    /*------------------------------------------------------------------------*/

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -2,6 +2,7 @@
 import { CompositeDisposable } from 'atom'
 import AtomBrowserViewBrowser from './atom-browser-view-browser'
 import AtomBrowserViewIcon from './atom-browser-view-icon'
+import AtomBrowserServer from './atom-browser-server'
 
 import {
    CONFIG_WEBVIEW_BACKGROUND,
@@ -10,6 +11,7 @@ import {
    CONFIG_SHOW_ICON,
    CONFIG_EMITTER_ENABLED,
    CONFIG_AUTO_DEVTOOLS,
+   CONFIG_STATIC_SERVE,
 } from './atom-browser-confignames'
 
 export default {
@@ -20,6 +22,7 @@ export default {
       this.initialUrl = atom.config.get(CONFIG_INITIAL_URL)
       this.showIcon = false
       this.view = undefined
+      this.server = new AtomBrowserServer
 
       this.addSubscriptions()
       this.listenForSave()
@@ -75,14 +78,35 @@ export default {
 
    onPreview() {
       this.show()
+      
       // get the selected path
       var selected = document.querySelector('.atom-dock-inner .selected .name')
       if (!selected) return
-
-      var path = selected.getAttribute('data-path')
-      const fileURL = 'file://' + path
-
-      this.view.setURL(fileURL)
+      var selectedPath = selected.getAttribute('data-path')
+      
+      
+      var projectPath = undefined
+      var pointer = selected
+      var tried = 1000 // just in case :]
+      while (!projectPath && tried--) {
+         if (pointer.classList.contains('project-root')) {
+            projectPath = pointer.querySelector('.project-root-header span.name.icon').dataset.path
+         }
+         
+         var pointer = pointer.parentElement
+      }
+      
+      
+      const selectedFile = selectedPath.replace(projectPath, '')
+   
+      if (atom.config.get(CONFIG_STATIC_SERVE)) {
+         this.server.start(projectPath, (serverUrl) => {
+            this.view.setURL(serverUrl + selectedFile)
+         })
+      } else {
+         const fileURL = 'file://' + selectedPath
+         this.view.setURL(fileURL)
+      }
    },
 
    /*------------------------------------------------------------------------*/
@@ -215,6 +239,7 @@ export default {
    },
 
    onDestroyItem({ item }) {
+      this.server.tearDown()
       if (item instanceof AtomBrowserViewBrowser) {
          this.view = undefined
       }

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -86,13 +86,13 @@ export default {
 
    onPreview() {
       this.show()
-      
+
       // get the selected path
       var selected = document.querySelector('.atom-dock-inner .selected .name')
       if (!selected) return
       var selectedPath = selected.getAttribute('data-path')
-      
-      
+
+
       var projectPath = undefined
       var pointer = selected
       var tried = 1000 // just in case :]
@@ -100,13 +100,13 @@ export default {
          if (pointer.classList.contains('project-root')) {
             projectPath = pointer.querySelector('.project-root-header span.name.icon').dataset.path
          }
-         
+
          var pointer = pointer.parentElement
       }
-      
-      
+
+
       const selectedFile = selectedPath.replace(projectPath, '')
-   
+
       if (atom.config.get(CONFIG_STATIC_SERVE)) {
          this.server.start(projectPath, (serverUrl) => {
             this.view.setURL(serverUrl + selectedFile)
@@ -147,7 +147,7 @@ export default {
          zoomFactor: this.zoomFactor,
       })
 
-      atom.workspace.open(this.view)  
+      atom.workspace.open(this.view)
       this.changeConfigDefaultLocation()
    },
 
@@ -194,16 +194,16 @@ export default {
    changeConfigEmitter() {
       this.view && this.view.ipcToggle()
    },
-   
+
    changeReloadByDefault() {
       this.reloadByDefault = atom.config.get(CONFIG_RELOAD_BY_DEFAULT)
    },
-   
+
    changeShowZoom() {
       this.showZoomButtons = atom.config.get(CONFIG_SHOW_ZOOM)
       this.view && this.view.zoomToggle(this.showZoomButtons)
    },
-   
+
    changeZoomFactor() {
       this.zoomFactor = atom.config.get(CONFIG_ZOOM_FACTOR)
       this.view && this.view.zoomSet(this.zoomFactor)

--- a/lib/atom-browser.js
+++ b/lib/atom-browser.js
@@ -13,15 +13,16 @@ import {
    CONFIG_SHOW_ZOOM,
    CONFIG_STATIC_SERVE,
    CONFIG_WEBVIEW_BACKGROUND,
+   CONFIG_ZOOM_FACTOR,
 } from './atom-browser-confignames'
 
 export default {
    activate() {
-      console.log('dev mode')
       this.subscriptions = null
       this.dockLocation = atom.config.get(CONFIG_DEFAULT_LOCATION)
       this.showBackground = atom.config.get(CONFIG_WEBVIEW_BACKGROUND)
       this.showZoomButtons = atom.config.get(CONFIG_SHOW_ZOOM)
+      this.zoomFactor = atom.config.get(CONFIG_ZOOM_FACTOR)
       this.initialUrl = atom.config.get(CONFIG_INITIAL_URL)
       this.reloadByDefault = atom.config.get(CONFIG_RELOAD_BY_DEFAULT)
       this.showIcon = false
@@ -66,6 +67,7 @@ export default {
          atom.config.onDidChange(CONFIG_EMITTER_ENABLED, () => this.changeConfigEmitter()),
          atom.config.onDidChange(CONFIG_SHOW_ZOOM, () => this.changeShowZoom()),
          atom.config.onDidChange(CONFIG_RELOAD_BY_DEFAULT, () => this.changeReloadByDefault()),
+         atom.config.onDidChange(CONFIG_ZOOM_FACTOR, () => this.changeZoomFactor()),
          atom.workspace.getRightDock().getPanes()[0].onWillDestroyItem((e) => this.onDestroyItem(e)),
          atom.workspace.getBottomDock().getPanes()[0].onWillDestroyItem((e) => this.onDestroyItem(e)),
          atom.workspace.getRightDock().getPanes()[0].onDidAddItem((e) => this.onDidMoveItem(e, 'right')),
@@ -142,6 +144,7 @@ export default {
          reloadByDefault: this.reloadByDefault,
          initialUrl: this.initialUrl,
          showZoomButtons: this.showZoomButtons,
+         zoomFactor: this.zoomFactor,
       })
 
       atom.workspace.open(this.view)  
@@ -198,8 +201,12 @@ export default {
    
    changeShowZoom() {
       this.showZoomButtons = atom.config.get(CONFIG_SHOW_ZOOM)
-      console.log('uhhhh', this.showZoomButtons, atom.config.get(CONFIG_SHOW_ZOOM), CONFIG_SHOW_ZOOM)
-      this.view && this.view.toggleZoomButtons(this.showZoomButtons)
+      this.view && this.view.zoomToggle(this.showZoomButtons)
+   },
+   
+   changeZoomFactor() {
+      this.zoomFactor = atom.config.get(CONFIG_ZOOM_FACTOR)
+      this.view && this.view.zoomSet(this.zoomFactor)
    },
 
    /*------------------------------------------------------------------------*/

--- a/lib/views/Navbar.js
+++ b/lib/views/Navbar.js
@@ -1,11 +1,11 @@
-module.exports = () => {
+module.exports = ({ reloadByDefault }) => {
    return  `
       <atom-panel id="atombrowser-navbar" class="padded native-key-bindings">
 
          <!-- back / reload / refresh-on-save -->
          <button id="atombrowser-btn-back" class="btn"><i class="icon icon-chevron-left"></i></button>
          <button id="atombrowser-btn-reload" class="btn"><i class="icon icon-sync"></i></button>
-         <button id="atombrowser-btn-livereload" class="btn"><i class="icon icon-zap"></i></button>
+         <button id="atombrowser-btn-livereload" class="btn ${reloadByDefault ? 'active' : ''}"><i class="icon icon-zap"></i></button>
 
          <!-- addressbar -->
          <input type="text" id="atombrowser-addressbar" class="input-text native-key-bindings" placeholder="Search, File, Url"/>

--- a/lib/views/Navbar.js
+++ b/lib/views/Navbar.js
@@ -1,4 +1,4 @@
-module.exports = ({ reloadByDefault }) => {
+module.exports = ({ reloadByDefault, showZoomButtons }) => {
    return  `
       <atom-panel id="atombrowser-navbar" class="padded native-key-bindings">
 
@@ -12,7 +12,13 @@ module.exports = ({ reloadByDefault }) => {
 
          <!-- open devtools -->
          <button id="atombrowser-btn-devtools" class="btn"><i class="icon icon-terminal"></i></button>
-
+         
+         <!-- EXPERIMENTAL: ZOOM BAR -->
+         <div class="zoom-bar ${showZoomButtons ? "" : "hidden"}">
+            <button id="atombrowser-btn-zoom-out" class="btn"><i class="icon icon-dash"></i></button>
+            <input class='input-text' type='text' placeholder='Text' value="100" style="width: 4rem; text-align: center;">
+            <button id="atombrowser-btn-zoom-in" class="btn"><i class="icon icon-plus"></i></button>
+         </div>
       </atom-panel>
    `.trim()
 }

--- a/lib/views/Navbar.js
+++ b/lib/views/Navbar.js
@@ -1,4 +1,4 @@
-module.exports = ({ reloadByDefault, showZoomButtons }) => {
+module.exports = ({ reloadByDefault, showZoomButtons, zoomFactor }) => {
    return  `
       <atom-panel id="atombrowser-navbar" class="padded native-key-bindings">
 
@@ -16,7 +16,7 @@ module.exports = ({ reloadByDefault, showZoomButtons }) => {
          <!-- EXPERIMENTAL: ZOOM BAR -->
          <div class="zoom-bar ${showZoomButtons ? "" : "hidden"}">
             <button id="atombrowser-btn-zoom-out" class="btn"><i class="icon icon-dash"></i></button>
-            <input class='input-text' type='text' placeholder='Text' value="100" style="width: 4rem; text-align: center;">
+            <input readonly id="atombrowser-input-zoom" class='input-text' type='text' placeholder='Text' value="${Math.round(zoomFactor * 100)}" style="width: 4rem; text-align: center;">
             <button id="atombrowser-btn-zoom-in" class="btn"><i class="icon icon-plus"></i></button>
          </div>
       </atom-panel>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,371 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "inspirational-quotes": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/inspirational-quotes/-/inspirational-quotes-1.0.8.tgz",
-      "integrity": "sha512-G6bUixnxETEac36tXWT/EuSJ2BzZ+smiBb8cKYLYOiGgdaRnBiwhMouLB+l0eLmAa3Pokz04pto6i4Ro2UomkA=="
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
       },
       "z_experimental": {
          "type": "object",
-         "title": "⚠️Experimental Features",
+         "title": "⚠️ Experimental Features",
          "properties": {
             "emitterEnabled": {
                "title": "Save ScrollY on reload",
@@ -127,8 +127,17 @@
                "description": "Paths to overwrite when right click previewing a file. Allows you to map a filepath to your localhost!",
                "type": "string",
                "default": "[ { \"replace\": \"example/filepath\", \"with\": \"localhost:8000\" } ]"
+            },
+            "static_server": {
+               "title": "Static Serve",
+               "description": "Preview files from a local webserver",
+               "type": "boolean",
+               "default": "false"
             }
          }
       }
+   },
+   "dependencies": {
+      "express": "^4.17.1"
    }
 }

--- a/package.json
+++ b/package.json
@@ -51,23 +51,31 @@
       }
    },
    "configSchema": {
-      "reloadDelay": {
-         "title": "Reload on save delay",
-         "description": "Time in ms to wait before reloading (1000ms = 1second)",
-         "type": "integer",
-         "default": 250
-      },
       "reloadByDefault": {
          "title": "Reload by default",
          "description": "Toggles auto reload to be on by default",
          "type": "boolean",
          "default": false
       },
+      "reloadDelay": {
+         "title": "Reload on save delay",
+         "description": "Time in ms to wait before reloading (1000ms = 1second)",
+         "type": "integer",
+         "default": 250
+      },
       "showZoomButtons": {
          "title": "Show zoom buttons",
          "description": "Toggles zoom buttons",
          "type": "boolean",
          "default": false
+      },
+      "showZoomFactor": {
+         "title": "Zoom Factor",
+         "description": "Changes the zoom factor to the specified factor. Zoom factor is zoom percent divided by 100, so 300% = 3.0.",
+         "type": "number",
+         "default": 1,
+         "minimum": 0.1,
+         "maximum": 5
       },
       "showIcon": {
          "title": "Show Statusbar Icon",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
          "type": "integer",
          "default": 250
       },
+      "reloadByDefault": {
+         "title": "Reload by default",
+         "description": "Toggles auto reload to be on by default",
+         "type": "boolean",
+         "default": false
+      },
       "showIcon": {
          "title": "Show Statusbar Icon",
          "description": "Toggles the statusbar icon",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,12 @@
          "type": "boolean",
          "default": false
       },
+      "showZoomButtons": {
+         "title": "Show zoom buttons",
+         "description": "Toggles zoom buttons",
+         "type": "boolean",
+         "default": false
+      },
       "showIcon": {
          "title": "Show Statusbar Icon",
          "description": "Toggles the statusbar icon",

--- a/styles/atom-browser.less
+++ b/styles/atom-browser.less
@@ -73,6 +73,8 @@
    display: flex;
    border-bottom: none;
    padding: 6px;
+   min-height: 3.5rem;
+   height: 3.5rem;
 
    #atombrowser-addressbar {
       width: 100%;

--- a/styles/atom-browser.less
+++ b/styles/atom-browser.less
@@ -9,42 +9,19 @@
 #atombrowser-view {
    box-sizing: border-box;
    z-index: 1;
-
-   #atombrowser-tabs {
-      border-bottom: none;
-      border-bottom: none;
-      top: 38px;
-      right: 17px;
-      position: absolute;
-
-      &:after {
-         position: absolute;
-         background: none;
-      }
-
-      &:before {
-         top: 8px;
-      }
-
-      .list-group li:hover {
-         background: @background-color-success;
-      }
-   }
+   display: flex;
+   flex-direction: column;
 }
 
 .atombrowser-webview-container {
    box-sizing: border-box;
-   position: absolute;
-   top: 0;
-   left: 0;
-   width: 100%;
-   height: 100%;
-   padding: 38px 8px 0;
+   flex: 1;
+   padding: 0 8px;
    color: white;
 
    #atombrowser-webview {
       left: 0;
-      top: 40px;
+      top: 0;
       box-sizing: border-box;
       width: 100%;
       height: 100%;

--- a/styles/atom-browser.less
+++ b/styles/atom-browser.less
@@ -79,7 +79,8 @@
    }
 
    button {
-      width: 35px;
+      width: 3rem;
+      min-width: 3rem;
       text-align: center;
       margin: 0 2px;
       padding: 0;
@@ -110,6 +111,10 @@
       &.active {
          background: @base-color;
       }
+   }
+   
+   .zoom-bar {
+      display: flex;
    }
 }
 


### PR DESCRIPTION
## zoom bar
Can toggle a zoom bar in settings. For feature request #40 #42 

![atom-browser-zoom-bar](https://user-images.githubusercontent.com/21677355/89860391-f8794400-db68-11ea-9bc2-8302fa7ab1fc.gif)

## open target="_blank" urls in same window
Urls that open in new tab, new window will now open in the current frame. Fixes #44 

## reload ignoring cache
Changing webview.reload to webview.reloadIgnoringCache to fix issue #43 

## fix font size bug with navbar
If changing atoms global font size the navbar could go overtop the webview. Changing the navbar/webview to use display flex

## reload by default config
Checkbox in settings to make auto reload active when previewing a file

## static serve experiment
Optional experimental feature. Previewing a file will start a static server for the project folder and use that url.

![Jun-28-2020 17-27-04](https://user-images.githubusercontent.com/21677355/85959861-a12a6600-b964-11ea-9b8a-fb6add54d264.gif)

