### PR TITLE
2021.1: fix getWebContents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,22 @@ Atom-Browser is the plugin to browse the web, preview files, auto-reload, and se
 
 ## Right click and preview your html files
 
-![Atom google example](https://github.com/sean-codes/atom-browser/blob/master/example_preview.gif?raw=true)
+![Atom google example](https://github.com/sean-codes/atom-browser/raw/master/example_preview.gif?v=3)
 
 
 ## Toggle Auto Reload on save
 
-![Atom google example](https://github.com/sean-codes/atom-browser/blob/master/example_reload.gif?raw=true)
+![Atom google example](https://github.com/sean-codes/atom-browser/raw/master/example_reload.gif?v=3)
 Now when you save a file atom-browser will reload the page
 
 ## Search Google
 
 Open Atom-Browser -> Type your search term -> Press Enter!
 
-![Atom google example](https://github.com/sean-codes/atom-browser/blob/master/example_search.gif?raw=true)
+![Atom google example](https://github.com/sean-codes/atom-browser/raw/master/example_search.gif?v=3)
 
 ## Features/Bugs/Help
 
 [Click Here: Will fix/add/help as soon as possible! Thank you! :\]](https://github.com/sean-codes/atom-browser/issues)
+
+If no response for multiple days please email me directly sean_codes@outlook.com!

--- a/lib/atom-browser-view-browser.js
+++ b/lib/atom-browser-view-browser.js
@@ -1,6 +1,6 @@
 'use babel';
 import { CompositeDisposable, Disposable } from 'atom'
-
+const { remote } = require('electron')
 const fs = require('fs')
 const ViewNavbar = require('./views/Navbar')
 const ViewWebview = require('./views/Webview')
@@ -163,7 +163,7 @@ export default class AtomBrowserViewBrowser {
    /*----------------------------| button actions |--------------------------*/
    /*------------------------------------------------------------------------*/
    devtools() {
-      if (!this.html.webview.getWebContents()) return
+      if (!this.getWebContents()) return
 
       this.html.webview.isDevToolsOpened()
          ? this.devtoolsHide()
@@ -220,7 +220,7 @@ export default class AtomBrowserViewBrowser {
    }
 
    reload() {
-      if (this.isInDom() && this.html.webview.getWebContents()) {
+      if (this.isInDom() && this.getWebContents()) {
          this.ipcDisconnect()
          this.html.webview.reloadIgnoringCache()
       }
@@ -256,7 +256,7 @@ export default class AtomBrowserViewBrowser {
    }
 
    back() {
-      if (this.html.webview.getWebContents() && this.html.webview.canGoBack())
+      if (this.getWebContents() && this.html.webview.canGoBack())
          this.html.webview.goBack()
    }
 
@@ -280,7 +280,7 @@ export default class AtomBrowserViewBrowser {
       this.zoomFactor = Math.round(this.zoomFactor * 100)/100
       atom.config.set(CONFIG_ZOOM_FACTOR, this.zoomFactor)
       this.html.inputZoom.value = Math.round(this.zoomFactor * 100)
-      if (this.html.webview.getWebContents()) {
+      if (this.getWebContents()) {
          this.html.webview.setZoomFactor(this.zoomFactor)
       }
    }
@@ -292,6 +292,10 @@ export default class AtomBrowserViewBrowser {
    applySettingViewBackground(show) {
       this.showBackground = show
       this.html.webview.classList.toggle('show-background', this.showBackground)
+   }
+
+   getWebContents() {
+      return this.html.webview && remote.webContents.fromId(this.html.webview.getWebContentsId())
    }
 
    destroy() {


### PR DESCRIPTION
repair for #48 

Looks like getWebContents was deprecated in newer version of electron 